### PR TITLE
Change registration expiry timer

### DIFF
--- a/sip.c
+++ b/sip.c
@@ -929,7 +929,7 @@ sip_task (void *arg)
       // Do registration logic
       if (sip.regexpiry < now)
          sip.regexpiry = 0;     // Actually expired
-      if (sip.regexpiry < now + 60 && sip.ichost && regretry < now)
+      if (sip.regexpiry < now + (cexpires / 2) && sip.ichost && regretry < now)
       {
          cstring_t host = sip.ichost;
          if (!strncasecmp (host, "sip:", 4))


### PR DESCRIPTION
I've been having some trouble with one of my SIP servers that sets a very short Expiry time on registraitons, (30s) 
The badge was in a constant registration loop every 2s, With some more testing of 60s 70s, 80s I discovered that the re-register is set to occur 60sec before the end of the current time.
However if your expiry is less than 60s this will loop, and if its 70s it will occur every 10s etc.

Instead of a fixed value of 60s I'm using half the expiry time which seeems to be a convention (the RFC doesn't specify) and will work with short registration timers of less than 60s.

This will increase the registrations for some scenarios, could also switch this to 25% remaining by using /4, 

Alternativly reducing the time left before re-reg from 60s to 15sec? 